### PR TITLE
Add metrics service

### DIFF
--- a/blockjoy/api/v1/metrics.proto
+++ b/blockjoy/api/v1/metrics.proto
@@ -5,13 +5,20 @@ package blockjoy.api.v1;
 import "node.proto";
 
 message NodeMetricsRequest {
+    // This field maps the id of the node to the metrics that apply to that node.
     map<string, Metrics> metrics = 1;
 }
 
+// The metrics for a single `Node`. Note that there is no node id in this message, because it is
+// embedded in the `NodeMetricsRequest`, where the key of the map already is the id of the node.
 message Metrics {
+    // This is the current height of the blockchain.
     optional uint64 height = 1;
+    // This is the age of the most recent block, measured in seconds.
     optional uint64 block_age = 2;
-    optional StakingStatus staking_status = 3;
+    // This is the current staking status of the node.
+    optional Node.StakingStatus staking_status = 3;
+    // Iff the blockchain is in consensus, this field is `true``.
     optional bool consensus = 4;
 }
 

--- a/blockjoy/api/v1/metrics.proto
+++ b/blockjoy/api/v1/metrics.proto
@@ -5,10 +5,10 @@ package blockjoy.api.v1;
 import "node.proto";
 
 message NodeMetricsRequest {
-    map<string, NodeMetricRequest> metrics = 1;
+    map<string, Metrics> metrics = 1;
 }
 
-message NodeMetricRequest {
+message Metrics {
     optional uint64 height = 1;
     optional uint64 block_age = 2;
     optional StakingStatus staking_status = 3;

--- a/blockjoy/api/v1/metrics.proto
+++ b/blockjoy/api/v1/metrics.proto
@@ -1,0 +1,31 @@
+syntax = "proto3";
+
+package blockjoy.api.v1;
+
+import "node.proto";
+
+message NodeMetricsRequest {
+    map<string, NodeMetricRequest> metrics = 1;
+}
+
+message NodeMetricRequest {
+    optional uint64 height = 1;
+    optional uint64 block_age = 2;
+    optional StakingStatus staking_status = 3;
+    optional bool consensus = 4;
+}
+
+message NodeMetricsResponse {}
+
+message HostMetricsRequest {
+    // todo
+}
+
+message HostMetricsResponse {}
+
+service Metrics {
+    // Overwrite the metrics for the given nodes.
+    rpc Node(NodeMetricsRequest) returns (NodeMetricsResponse);
+    // Overwrite the metrics for the giveb host.
+    rpc Host(HostMetricsRequest) returns (HostMetricsResponse);
+}

--- a/blockjoy/api/v1/node.proto
+++ b/blockjoy/api/v1/node.proto
@@ -5,21 +5,6 @@ package blockjoy.api.v1;
 import "google/protobuf/timestamp.proto";
 import "messages.proto";
 
-// Describe the node's staking status
-enum StakingStatus {
-    // Reserving values up to 15 for possible later use
-    // Up to 15 to ensure only 1 byte is used for the most common values
-    reserved 7 to 15;
-
-    UnknownStakingStatus = 0;
-    Follower = 1;
-    Staked = 2;
-    Staking = 3;
-    Validating = 4;
-    Consensus = 5;
-    Unstaked = 6;
-}
-
 message NodeInfo {
     // Possible states the container is described with
     enum ContainerStatus {
@@ -39,6 +24,21 @@ message NodeInfo {
         Deleted = 9;
         Installing = 10;
         Snapshotting = 11;
+    }
+
+    // Describe the node's staking status
+    enum StakingStatus {
+        // Reserving values up to 15 for possible later use
+        // Up to 15 to ensure only 1 byte is used for the most common values
+        reserved 7 to 15;
+
+        UnknownStakingStatus = 0;
+        Follower = 1;
+        Staked = 2;
+        Staking = 3;
+        Validating = 4;
+        Consensus = 5;
+        Unstaked = 6;
     }
 
     // Describe the node's syncing status

--- a/blockjoy/api/v1/node.proto
+++ b/blockjoy/api/v1/node.proto
@@ -5,6 +5,21 @@ package blockjoy.api.v1;
 import "google/protobuf/timestamp.proto";
 import "messages.proto";
 
+// Describe the node's staking status
+enum StakingStatus {
+    // Reserving values up to 15 for possible later use
+    // Up to 15 to ensure only 1 byte is used for the most common values
+    reserved 7 to 15;
+
+    UnknownStakingStatus = 0;
+    Follower = 1;
+    Staked = 2;
+    Staking = 3;
+    Validating = 4;
+    Consensus = 5;
+    Unstaked = 6;
+}
+
 message NodeInfo {
     // Possible states the container is described with
     enum ContainerStatus {
@@ -35,21 +50,6 @@ message NodeInfo {
         UndefinedSyncStatus = 0;
         Syncing = 1;
         Synced = 2;
-    }
-
-    // Describe the node's staking status
-    enum StakingStatus {
-        // Reserving values up to 15 for possible later use
-        // Up to 15 to ensure only 1 byte is used for the most common values
-        reserved 7 to 15;
-
-        UnknownStakingStatus = 0;
-        Follower = 1;
-        Staked = 2;
-        Staking = 3;
-        Validating = 4;
-        Consensus = 5;
-        Unstaked = 6;
     }
 
     // Describe the node's chain related status


### PR DESCRIPTION
Adds a metrics service that is used by blockvisord to push metrics about nodes and hosts to the api. The host metrics are left as a stub.