### PR TITLE
rework some of the bv api

### DIFF
--- a/blockjoy/api/v1/host.proto
+++ b/blockjoy/api/v1/host.proto
@@ -44,8 +44,10 @@ message ProvisionHostRequest {
   string name = 4;
   string version = 5;
   int64 cpu_count = 6;
-  int64 mem_size = 7;
-  int64 disk_size = 8;
+  // The amount of memory in bytes that the host should have.
+  int64 mem_size_bytes = 7;
+  // The amount of disk space in bytes that the host should have.
+  int64 disk_size_bytes = 8;
   string os = 9;
   string os_version = 10;
   string ip = 11;

--- a/blockjoy/api/v1/host.proto
+++ b/blockjoy/api/v1/host.proto
@@ -44,9 +44,9 @@ message ProvisionHostRequest {
   string name = 4;
   string version = 5;
   int64 cpu_count = 6;
-  // The amount of memory in bytes that the host should have.
+  // The amount of memory in bytes that the host has.
   int64 mem_size_bytes = 7;
-  // The amount of disk space in bytes that the host should have.
+  // The amount of disk space in bytes that the host has.
   int64 disk_size_bytes = 8;
   string os = 9;
   string os_version = 10;

--- a/blockjoy/api/v1/host.proto
+++ b/blockjoy/api/v1/host.proto
@@ -28,13 +28,13 @@ message Host {
 }
 
 message DeleteHostRequest {
-  optional string request_id = 1;
+  string request_id = 1;
   string host_id = 2;
 }
 
 message DeleteHostResponse {
   repeated string messages = 1;
-  optional string origin_request_id = 2;
+  string origin_request_id = 2;
 }
 
 message ProvisionHostRequest {
@@ -65,9 +65,6 @@ message HostUpdateRequest {
   optional string os = 4;
   optional string os_version = 5;
   optional string ip = 6;
-  optional string ip_range_from = 7;
-  optional string ip_range_to = 8;
-  optional string ip_gateway = 9;
 }
 
 message HostUpdateResponse {

--- a/blockjoy/api/v1/host.proto
+++ b/blockjoy/api/v1/host.proto
@@ -11,17 +11,17 @@ enum ConnectionStatus {
   CONNECTION_STATUS_OFFLINE = 2;
 }
 
-message HostInfo {
-  optional string id = 1;
-  optional string name = 2;
-  optional string version = 3;
+message Host {
+  string id = 1;
+  string name = 2;
+  string version = 3;
   optional string location = 4;
-  optional int64 cpu_count = 5;
-  optional int64 mem_size = 6;
-  optional int64 disk_size = 7;
-  optional string os = 8;
-  optional string os_version = 9;
-  optional string ip = 10;
+  int64 cpu_count = 5;
+  int64 mem_size = 6;
+  int64 disk_size = 7;
+  string os = 8;
+  string os_version = 9;
+  string ip = 10;
   optional string ip_range_from = 11;
   optional string ip_range_to = 12;
   optional string ip_gateway = 13;
@@ -38,27 +38,41 @@ message DeleteHostResponse {
 }
 
 message ProvisionHostRequest {
-  optional string request_id = 1;
+  string request_id = 1;
   string otp = 2;
-  HostInfo info = 3;
-  ConnectionStatus status = 4;
+  ConnectionStatus status = 3;
+  string name = 4;
+  string version = 5;
+  int64 cpu_count = 6;
+  int64 mem_size = 7;
+  int64 disk_size = 8;
+  string os = 9;
+  string os_version = 10;
+  string ip = 11;
 }
 
 message ProvisionHostResponse {
   string host_id = 1;
   string token = 2;
   repeated string messages = 3;
-  optional string origin_request_id = 4;
+  string origin_request_id = 4;
 }
 
-message HostInfoUpdateRequest {
-  optional string request_id = 1;
-  HostInfo info = 2;
+message HostUpdateRequest {
+  string request_id = 1;
+  string id = 2;
+  optional string version = 3;
+  optional string os = 4;
+  optional string os_version = 5;
+  optional string ip = 6;
+  optional string ip_range_from = 7;
+  optional string ip_range_to = 8;
+  optional string ip_gateway = 9;
 }
 
-message HostInfoUpdateResponse {
+message HostUpdateResponse {
   repeated string messages = 1;
-  optional string origin_request_id = 2;
+  string origin_request_id = 2;
 }
 
 message HostUpdateBVS {
@@ -75,7 +89,7 @@ message HostGenericCommand {
   repeated Parameter params = 1;
 }
 
-message HostInfoGet {
+message HostGet {
 }
 
 message HostCommand {
@@ -85,7 +99,7 @@ message HostCommand {
 
   oneof command {
     HostGenericCommand generic = 4;
-    HostInfoGet info_get = 5;
+    HostGet get = 5;
     HostUpdateBVS update_bvs = 6;
     HostRestartBVS restart_bvs = 7;
     HostRemoveBVS remove_bvs = 8;

--- a/blockjoy/api/v1/host_service.proto
+++ b/blockjoy/api/v1/host_service.proto
@@ -4,9 +4,10 @@ package blockjoy.api.v1;
 
 import "host.proto";
 
-service Hosts {
+service HostService {
+  // This endpoint creates a new host from an already created host provision.
   rpc Provision(ProvisionHostRequest) returns (ProvisionHostResponse);
-  rpc InfoUpdate(HostInfoUpdateRequest) returns (HostInfoUpdateResponse);
+  rpc Update(HostUpdateRequest) returns (HostUpdateResponse);
   /* Delete a single host */
   rpc Delete(DeleteHostRequest) returns (DeleteHostResponse);
 }

--- a/blockjoy/api/v1/key_file_service.proto
+++ b/blockjoy/api/v1/key_file_service.proto
@@ -3,31 +3,31 @@ syntax = "proto3";
 package blockjoy.api.v1;
 
 /**
-   * A single keyfile representation
-   */
+  * A single keyfile representation
+  */
 message Keyfile {
   string name = 1;
   bytes content = 2;
 }
 
 message KeyFilesGetRequest {
-  optional string request_id = 1;
+  string request_id = 1;
   string node_id = 2;
 }
 
 message KeyFilesGetResponse {
-  optional string origin_request_id = 1;
+  string origin_request_id = 1;
   repeated Keyfile key_files = 2;
 }
 
 message KeyFilesSaveRequest {
-  optional string request_id = 1;
+  string request_id = 1;
   string node_id = 2;
   repeated Keyfile key_files = 3;
 }
 
 message KeyFilesSaveResponse {
-  optional string origin_request_id = 1;
+  string origin_request_id = 1;
   repeated string messages = 2;
 }
 

--- a/blockjoy/api/v1/metrics.proto
+++ b/blockjoy/api/v1/metrics.proto
@@ -20,15 +20,15 @@ message NodeMetrics {
   // This is the age of the most recent block, measured in seconds.
   optional uint64 block_age = 2;
   // This is the current staking status of the node.
-  optional NodeInfo.StakingStatus staking_status = 3;
-  // Iff the blockchain is in consensus, this field is `true``.
+  optional Node.StakingStatus staking_status = 3;
+  // Iff the blockchain is in consensus, this field is `true`.
   optional bool consensus = 4;
   // This field represents the current status of the blockchain node
   // application.
-  optional NodeInfo.ApplicationStatus application_status = 5;
+  optional Node.ApplicationStatus application_status = 5;
   // The status of the node with respect to the rest of the network, i.e.
   // whether it is in sync with the other nodes.
-  optional NodeInfo.SyncStatus sync_status = 6;
+  optional Node.SyncStatus sync_status = 6;
 }
 
 // This message is used to store the metrics for a given set of hosts.

--- a/blockjoy/api/v1/node.proto
+++ b/blockjoy/api/v1/node.proto
@@ -119,7 +119,6 @@ message NodeUpgrade {
 
 message NodeUpdate {
   optional bool self_update = 1;
-  repeated Parameter properties = 2;
 }
 
 message NodeGet {

--- a/blockjoy/api/v1/node.proto
+++ b/blockjoy/api/v1/node.proto
@@ -5,12 +5,7 @@ package blockjoy.api.v1;
 import "google/protobuf/timestamp.proto";
 import "messages.proto";
 
-message NodeInfoUpdateRequest {
-  optional string request_id = 1;
-  NodeInfo info = 2;
-}
-
-message NodeInfo {
+message Node {
   // Possible states the container is described with
   enum ContainerStatus {
     // Reserving values up to 15 for possible later use
@@ -84,17 +79,34 @@ message NodeInfo {
   }
 
   string id = 1;
-  optional string name = 2;
+  string name = 2;
   optional string ip = 3;
-  optional bool self_update = 4;
+  bool self_update = 4;
   optional int64 block_height = 6;
   optional string onchain_name = 7;
   optional ApplicationStatus app_status = 8;
   optional ContainerStatus container_status = 9;
   optional SyncStatus sync_status = 10;
   optional StakingStatus staking_status = 11;
+  // This is the address of the node within the blockchain network. The
+  // IP-address is stored in the `ip_address` field.
   optional string address = 12;
-  optional string host_id = 13;
+  string host_id = 13;
+}
+
+message NodeUpdateRequest {
+  optional string request_id = 1;
+
+  string id = 2;
+  optional string ip = 3;
+  optional bool self_update = 4;
+  optional int64 block_height = 6;
+  optional string onchain_name = 7;
+  optional Node.ApplicationStatus app_status = 8;
+  optional Node.ContainerStatus container_status = 9;
+  optional Node.SyncStatus sync_status = 10;
+  optional Node.StakingStatus staking_status = 11;
+  optional string address = 12;
 }
 
 message NodeStart {
@@ -106,17 +118,18 @@ message NodeStop {
 message NodeRestart {
 }
 
+// Updates a node to use a new OS-image
 message NodeUpgrade {
   ContainerImage image = 1;
 }
 
-message NodeInfoUpdate {
+message NodeUpdate {
   optional string name = 1;
   optional bool self_update = 2;
   repeated Parameter properties = 3;
 }
 
-message NodeInfoGet {
+message NodeGet {
 }
 
 message NodeGenericCommand {
@@ -149,8 +162,8 @@ message NodeCommand {
     NodeStop stop = 6;
     NodeRestart restart = 7;
     NodeUpgrade upgrade = 8;
-    NodeInfoUpdate update = 9;
-    NodeInfoGet info_get = 10;
+    NodeUpdate update = 9;
+    NodeGet info_get = 10;
     NodeCreate create = 11;
     NodeDelete delete = 12;
     NodeFirewallUpdate firewall_update = 14;
@@ -170,7 +183,7 @@ enum Direction {
   DIRECTION_IN = 2;
 }
 
-enum Protocol{
+enum Protocol {
   PROTOCOL_BOTH_UNSPECIFIED = 0;
   PROTOCOL_TCP = 1;
   PROTOCOL_UDP = 2;

--- a/blockjoy/api/v1/node.proto
+++ b/blockjoy/api/v1/node.proto
@@ -95,18 +95,12 @@ message Node {
 }
 
 message NodeUpdateRequest {
-  optional string request_id = 1;
-
+  string request_id = 1;
   string id = 2;
   optional string ip = 3;
   optional bool self_update = 4;
-  optional int64 block_height = 6;
-  optional string onchain_name = 7;
-  optional Node.ApplicationStatus app_status = 8;
-  optional Node.ContainerStatus container_status = 9;
-  optional Node.SyncStatus sync_status = 10;
-  optional Node.StakingStatus staking_status = 11;
-  optional string address = 12;
+  optional Node.ContainerStatus container_status = 5;
+  optional string address = 6;
 }
 
 message NodeStart {
@@ -124,9 +118,8 @@ message NodeUpgrade {
 }
 
 message NodeUpdate {
-  optional string name = 1;
-  optional bool self_update = 2;
-  repeated Parameter properties = 3;
+  optional bool self_update = 1;
+  repeated Parameter properties = 2;
 }
 
 message NodeGet {

--- a/blockjoy/api/v1/node_service.proto
+++ b/blockjoy/api/v1/node_service.proto
@@ -5,7 +5,7 @@ package blockjoy.api.v1;
 import "google/protobuf/empty.proto";
 import "node.proto";
 
-service Nodes {
+service NodeService {
   /* Update a single node */
-  rpc InfoUpdate(NodeInfoUpdateRequest) returns (google.protobuf.Empty);
+  rpc Update(NodeUpdateRequest) returns (google.protobuf.Empty);
 }


### PR DESCRIPTION
Instead of using the same message for creating, updating and returning entities, we use a separate message. This allows us to mark all fields that are required as actually required. This results in, for example, `Host.id` becoming a required field, and it not being possible to update the name of a running node.