### PR TITLE
Explicit supported node types, instead of just a string

### DIFF
--- a/v1/blockchain.proto
+++ b/v1/blockchain.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package v1;
 
 import "google/protobuf/timestamp.proto";
+import "node.proto";
 
 message Blockchain {
   enum BlockchainStatus {
@@ -23,8 +24,18 @@ message Blockchain {
   optional string version = 7;
   google.protobuf.Timestamp created_at = 8;
   optional google.protobuf.Timestamp updated_at = 9;
-  string supported_nodes_types = 10;
+  // This list contains all the possible node types that can be created for this
+  // kind of blockchain.
+  repeated SupportedNodeType nodes_types = 10;
   repeated BlockchainNetwork networks = 11;
+}
+
+// Blockchain related service.
+service Blockchains {
+  // Returns a single blockchain as identified by its id.
+  rpc Get(GetBlockchainRequest) returns (GetBlockchainResponse);
+  // Returns a list of all blockchains.
+  rpc List(ListBlockchainsRequest) returns (ListBlockchainsResponse);
 }
 
 message BlockchainNetwork {
@@ -40,12 +51,26 @@ message BlockchainNetwork {
   NetworkType net_type = 3;
 }
 
-// Blockchain related service.
-service Blockchains {
-  // Returns a single blockchain as identified by its id.
-  rpc Get(GetBlockchainRequest) returns (GetBlockchainResponse);
-  // Returns a list of all blockchains.
-  rpc List(ListBlockchainsRequest) returns (ListBlockchainsResponse);
+message SupportedNodeType {
+  Node.NodeType node_type = 1;
+  string version = 2;
+  repeated SupportedNodeProperty properties = 3;
+}
+
+message SupportedNodeProperty {
+  string name = 1;
+  string default = 2;
+  UiType ui_type = 3;
+  bool disabled = 4;
+  bool required = 5;
+}
+
+enum UiType {
+  UI_TYPE_UNSPECIFIED = 0;
+  UI_TYPE_SWITCH = 1;
+  UI_TYPE_PASSWORD = 2;
+  UI_TYPE_TEXT = 3;
+  UI_TYPE_FILE_UPLOAD = 4;
 }
 
 message GetBlockchainRequest {


### PR DESCRIPTION
Each blockchain has an associated list of supported node types. This list is currently being read from the database, and sent as a string. That is not very usable for devs reading our docs. The docs just say "string", whereas there is a whole nested object structure in there that we _could_ document in our protos. This pull request does exactly that: instead of sending a json string we use gRPC to return a list of sub-messages.