### PR TITLE
feat: remove ContainerImageStatus

### DIFF
--- a/blockjoy/v1/command.proto
+++ b/blockjoy/v1/command.proto
@@ -153,14 +153,6 @@ message Parameter {
   string value = 2;
 }
 
-// Define config status
-enum ContainerImageStatus {
-  CONTAINER_IMAGE_STATUS_UNSPECIFIED = 0;
-  CONTAINER_IMAGE_STATUS_DEVELOPMENT = 1;
-  CONTAINER_IMAGE_STATUS_UNSTABLE = 2;
-  CONTAINER_IMAGE_STATUS_STABLE = 3;
-}
-
 message ContainerImage {
   // snake_cased name of the blockchain
   string protocol = 1;
@@ -168,7 +160,6 @@ message ContainerImage {
   NodeType node_type = 2;
   // semantic version string of the node type version
   string node_version = 3;
-  ContainerImageStatus status = 4;
 }
 
 message Rule {


### PR DESCRIPTION
As discussed with @densone, env will define the type of images served by cookbook.
E.g. dev image will be served only on dev env, and so on.
So this config will be unnecessary.