### PR TITLE
Add mac address to the protos

### DIFF
--- a/blockjoy/v1/command.proto
+++ b/blockjoy/v1/command.proto
@@ -118,6 +118,8 @@ message NodeCreate {
   repeated Parameter properties = 7;
   repeated Rule rules = 8;
   string network = 9;
+  // The mac address represented as a string. Example: `CA:92:34:01:23:45`.
+  string mac_address = 10;
 }
 
 message NodeDelete {

--- a/blockjoy/v1/node.proto
+++ b/blockjoy/v1/node.proto
@@ -45,6 +45,8 @@ message Node {
   repeated FilteredIpAddr deny_ips = 29;
   // Logic with regards to where the node should placed.
   NodePlacement placement = 30;
+  // The mac address represented as a string. Example: `CA:92:34:01:23:45`.
+  string mac_address = 31;
 }
 
 service NodeService {


### PR DESCRIPTION
Includes the Mac address of the node with the Node and NodeCreate messages. Note that it is represented as a string, not as an integer. MAC addresses are actually 48 bit numbers, so it would fit inside of a u64, but that is ugly and I think that the increased inspectability is worth the overhead over the wire.