### PR TITLE
Nest blockchain versions

### DIFF
--- a/blockjoy/v1/blockchain.proto
+++ b/blockjoy/v1/blockchain.proto
@@ -8,16 +8,14 @@ import "google/protobuf/timestamp.proto";
 message Blockchain {
   string id = 1;
   string name = 2;
-  string description = 3;
-  optional string project_url = 4;
-  optional string repo_url = 5;
-  optional string version = 6;
-  google.protobuf.Timestamp created_at = 7;
-  optional google.protobuf.Timestamp updated_at = 8;
+  optional string description = 3;
+  google.protobuf.Timestamp created_at = 4;
+  google.protobuf.Timestamp updated_at = 5;
+  optional string project_url = 6;
+  optional string repo_url = 7;
   // This list contains all the possible node types that can be created for this
   // kind of blockchain.
-  repeated SupportedNodeType nodes_types = 9;
-  repeated BlockchainNetwork networks = 10;
+  repeated BlockchainNodeType node_types = 8;
 }
 
 // Blockchain related service.
@@ -44,18 +42,53 @@ message BlockchainServiceListResponse {
   repeated Blockchain blockchains = 1;
 }
 
-message SupportedNodeType {
-  NodeType node_type = 1;
-  string version = 2;
-  repeated SupportedNodeProperty properties = 3;
+message BlockchainNodeType {
+  string id = 1;
+  NodeType node_type = 2;
+  optional string description = 3;
+  google.protobuf.Timestamp created_at = 4;
+  google.protobuf.Timestamp updated_at = 5;
+  repeated BlockchainVersion versions = 6;
 }
 
-message SupportedNodeProperty {
+message BlockchainVersion {
+  string id = 1;
+  string version = 2;
+  optional string description = 3;
+  google.protobuf.Timestamp created_at = 4;
+  google.protobuf.Timestamp updated_at = 5;
+  repeated BlockchainNetwork networks = 6;
+  repeated BlockchainProperty properties = 7;
+}
+
+// A property that is supported by a node of a particular:
+// 1. blockchain type,
+// 2. node type,
+// 3. version.
+// When a blockchain node is created, a list of properties must be submitted by
+// the caller. The properties that are required / allowed are defined by these
+// properties here.
+message BlockchainProperty {
+  // The name of this property, i.e. `validator-key`.
   string name = 1;
-  optional string default = 2;
-  UiType ui_type = 3;
-  bool disabled = 4;
+  // A nice looking name that can be used for display purposes.
+  string display_name = 2;
+  // If there is one, this field contains the default value that should be
+  // used if the user supplies no value.
+  optional string default = 3;
+  // The way this field should be displayed when a node with this property is
+  // created.
+  UiType ui_type = 4;
+  // If this is true then the property _must_ be supplied when a node of this
+  // type and version is created. If this is false, then the property is treated
+  // as optional and may be omitted.
   bool required = 5;
+}
+
+message BlockchainNetwork {
+  string name = 1;
+  string url = 2;
+  BlockchainNetworkType net_type = 3;
 }
 
 enum BlockchainNetworkType {
@@ -63,10 +96,4 @@ enum BlockchainNetworkType {
   BLOCKCHAIN_NETWORK_TYPE_DEV = 1;
   BLOCKCHAIN_NETWORK_TYPE_TEST = 2;
   BLOCKCHAIN_NETWORK_TYPE_MAIN = 3;
-}
-
-message BlockchainNetwork {
-  string name = 1;
-  string url = 2;
-  BlockchainNetworkType net_type = 3;
 }

--- a/blockjoy/v1/cookbook.proto
+++ b/blockjoy/v1/cookbook.proto
@@ -6,6 +6,8 @@ syntax = "proto3";
 
 package blockjoy.v1;
 
+import "blockjoy/v1/node.proto";
+
 // ----------------------------- Cookbook Service -----------------------------
 
 // Babel cookbook service.
@@ -75,7 +77,7 @@ message CookbookServiceNetConfigurationsResponse {
 
 message CookbookServiceListBabelVersionsRequest {
   string protocol = 1;
-  string node_type = 2;
+  NodeType node_type = 2;
 }
 
 message CookbookServiceListBabelVersionsResponse {
@@ -264,7 +266,7 @@ message ConfigIdentifier {
   // snake_cased name of the blockchain.
   string protocol = 1;
   // snake_cased name of the node type.
-  string node_type = 2;
+  NodeType node_type = 2;
   // semantic version string of the node type version.
   string node_version = 3;
 }

--- a/blockjoy/v1/node.proto
+++ b/blockjoy/v1/node.proto
@@ -345,9 +345,15 @@ enum NodeType {
 
 enum UiType {
   UI_TYPE_UNSPECIFIED = 0;
+  // Either "true" or "false" must be returned. The property should be rendered
+  // as a checkbox.
   UI_TYPE_SWITCH = 1;
+  // This field should be treated as a password field, i.e. a text field whose
+  // content is hidden.
   UI_TYPE_PASSWORD = 2;
+  // This field should be treated as a text field.
   UI_TYPE_TEXT = 3;
+  // This field should let the user upload string from a file.
   UI_TYPE_FILE_UPLOAD = 4;
 }
 


### PR DESCRIPTION
Instead of a flat structure we now have blockchain > node types > versions > (networks and properties). This is required for when the various node types have different versions, or when a new version adds or removes a property that we want to support.