### PR TITLE
include url in node message

### DIFF
--- a/blockjoy/v1/node.proto
+++ b/blockjoy/v1/node.proto
@@ -55,7 +55,7 @@ message Node {
   optional string note = 35;
   // If this is an rpc node, this field contains the url where rpc requests can
   // be sent to.
-  optional string rpc_url = 36;
+  string url = 36;
 }
 
 // Service for interacting with a node.

--- a/blockjoy/v1/node.proto
+++ b/blockjoy/v1/node.proto
@@ -53,6 +53,9 @@ message Node {
   // A note you can use to explain what this node is for, or alternatively use
   // as a shopping list.
   optional string note = 35;
+  // If this is an rpc node, this field contains the url where rpc requests can
+  // be sent to.
+  optional string rpc_url = 36;
 }
 
 // Service for interacting with a node.


### PR DESCRIPTION
Jason changed the base for the rpc urls for our nodes
From n0des.xyz to something with a less exotic top level domain name
He had a couple of tools that didn't recognise the .xyz as a valid TLD
But we don't actually store the rpc url for our nodes anywhere
Now we will